### PR TITLE
Test: child_process

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "start": "NODE_ENV=test npm test -- -w",
     "lint": "standard",
-    "test": "NODE_ENV=test nyc --check-coverage --lines 80 ava --timeout=30s",
+    "test": "NODE_ENV=test nyc --check-coverage --lines 80 ava test/index.spec.js --timeout=30s",
     "coverage": "nyc report --reporter=lcov",
     "ci.coverage": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "scripts": {
     "start": "NODE_ENV=test npm test -- -w",
     "lint": "standard",
-    "test": "NODE_ENV=test nyc --check-coverage --lines 80 ava test/index.spec.js --timeout=30s",
+    "test": "NODE_ENV=test nyc --check-coverage --lines 80 ava --timeout=30s",
     "coverage": "nyc report --reporter=lcov",
     "ci.coverage": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -4,13 +4,13 @@ const path = require('path')
 const laabr = require('../src')
 const utils = require('../src/utils')
 
-function spawnServer(type, options, injection, done, stream = 'stdout') {
+function spawnServer (type, options, injection, done, stream = 'stdout', listener = 'once') {
   const childProcess = spawn(
     'node',
     [path.join(__dirname, `fixtures/${type}`), JSON.stringify(options), JSON.stringify(injection)]
   )
 
-  childProcess[stream].once('data', (data) => {
+  childProcess[stream][listener]('data', (data) => {
     let log = data.toString()
 
     try {
@@ -127,5 +127,5 @@ module.exports = {
   noop: utils.noop,
   spawn: spawnServer,
   getServer,
-  registerPlugin,
+  registerPlugin
 }

--- a/test/correlator.spec.js
+++ b/test/correlator.spec.js
@@ -3,18 +3,13 @@ const helpers = require('./_helpers')
 const laabr = require('../src')
 
 let consoleClone
-let interceptOut
-let interceptErr
 
 test.beforeEach('setup interceptor', (t) => {
   consoleClone = Object.assign({}, console)
-  interceptOut = helpers.getInterceptor()
-  interceptErr = helpers.getInterceptor({ stream: process.stderr })
 })
 
 test.afterEach.always('cleanup interceptor', (t) => {
   Object.assign(console, consoleClone)
-  helpers.disableInterceptor(interceptOut, interceptErr)
 })
 
 test.cb.serial('correlator is not exposed – laabr', (t) => {

--- a/test/correlator.spec.js
+++ b/test/correlator.spec.js
@@ -4,11 +4,11 @@ const laabr = require('../src')
 
 let consoleClone
 
-test.beforeEach('setup interceptor', (t) => {
+test.beforeEach((t) => {
   consoleClone = Object.assign({}, console)
 })
 
-test.afterEach.always('cleanup interceptor', (t) => {
+test.afterEach.always((t) => {
   Object.assign(console, consoleClone)
 })
 

--- a/test/correlator.spec.js
+++ b/test/correlator.spec.js
@@ -64,143 +64,177 @@ test.cb.serial('correlator is exposed – server.cid', (t) => {
 })
 
 test.cb.serial('CID is the same even in other function', (t) => {
-  helpers.getServer({ correlator: true }, (server) => {
-    server.on('tail', () => {
-      const [log1, log2] = interceptOut.filter('cid')
+  const options = { correlator: true }
 
-      t.truthy(log1)
-      t.truthy(log2)
-      t.is(log1, log2)
+  const injection = {
+    method: 'GET',
+    url: '/request/id'
+  }
+
+  let log1
+
+  helpers.spawn('inject', options, injection, (log) => {
+    t.truthy(log)
+
+    if (!log1) {
+      log1 = log
+    } else {
+      t.is(log1, log)
       t.end()
-    })
-
-    server.inject({
-      method: 'GET',
-      url: '/request/id'
-    })
-  })
+    }
+  }, undefined, 'on')
 })
 
 test.cb.serial('CID is the same even in other function – `response` event', (t) => {
-  laabr.format('response', 'cid :cid')
-  helpers.getServer({ correlator: true }, (server) => {
-    server.on('tail', () => {
-      const [log1, log2, log3] = interceptOut.filter('cid')
+  const options = {
+    correlator: true,
+    formats: { response: 'cid :cid' }
+  }
 
-      t.truthy(log1)
-      t.truthy(log2)
-      t.truthy(log3)
+  const injection = {
+    method: 'GET',
+    url: '/request/id'
+  }
+
+  let log1
+  let log2
+
+  helpers.spawn('inject', options, injection, (log) => {
+    t.truthy(log)
+
+    if (!log1) {
+      log1 = log
+    } else if (!log2) {
+      log2 = log
+    } else {
       t.is(log1, log2)
-      t.is(log1, log3)
-      t.is(log2, log3)
+      t.is(log1, log)
+      t.is(log2, log)
       t.end()
-    })
-
-    server.inject({
-      method: 'GET',
-      url: '/request/id'
-    })
-  })
+    }
+  }, undefined, 'on')
 })
 
 test.cb.serial('CID is the same even in other function – req.headers["x-laabr-cid"]', (t) => {
-  helpers.getServer({ correlator: true }, (server) => {
-    server.on('tail', () => {
-      const [log1, log2] = interceptOut.filter('cid')
+  const options = { correlator: true }
 
-      t.truthy(log1)
-      t.truthy(log2)
-      t.is(log1, log2)
+  const injection = {
+    method: 'GET',
+    url: '/request/id/req'
+  }
+
+  let log1
+
+  helpers.spawn('inject', options, injection, (log) => {
+    t.truthy(log)
+
+    if (!log1) {
+      log1 = log
+    } else {
+      t.is(log1, log)
       t.end()
-    })
-
-    server.inject({
-      method: 'GET',
-      url: '/request/id/req'
-    })
-  })
+    }
+  }, undefined, 'on')
 })
 
 test.cb.serial('CID is not the same because of `with`', (t) => {
-  helpers.getServer({ correlator: true }, (server) => {
-    server.on('tail', () => {
-      const [log1, log2] = interceptOut.filter('cid')
+  const options = { correlator: true }
 
-      t.truthy(log1)
-      t.truthy(log2)
-      t.not(log1, log2)
+  const injection = {
+    method: 'GET',
+    url: '/request/id/next'
+  }
+
+  let log1
+
+  helpers.spawn('inject', options, injection, (log) => {
+    t.truthy(log)
+
+    if (!log1) {
+      log1 = log
+    } else {
+      t.not(log1, log)
       t.end()
-    })
-
-    server.inject({
-      method: 'GET',
-      url: '/request/id/next'
-    })
-  })
+    }
+  }, undefined, 'on')
 })
 
 test.cb.serial('use the unset `x-correlation-id` header', (t) => {
-  helpers.getServer({ correlator: true }, (server) => {
-    server.on('tail', () => {
-      const [log1, log2] = interceptOut.filter('cid')
+  const options = { correlator: true }
 
-      t.truthy(log1)
-      t.truthy(log2)
-      t.is(log1, log2)
-      t.regex(log1, /^cid \d+:.+:.+\n$/)
-      t.regex(log2, /^cid \d+:.+:.+\n$/)
+  const injection = {
+    method: 'GET',
+    url: '/request/id'
+  }
+
+  let log1
+
+  helpers.spawn('inject', options, injection, (log) => {
+    t.truthy(log)
+    t.regex(log, /^cid \d+:.+:.+/)
+
+    if (!log1) {
+      log1 = log
+    } else {
+      t.is(log1, log)
       t.end()
-    })
-
-    server.inject({
-      method: 'GET',
-      url: '/request/id'
-    })
-  })
+    }
+  }, undefined, 'on')
 })
 
 test.cb.serial('use the set `x-correlation-id` header', (t) => {
-  helpers.getServer({ correlator: true }, (server) => {
-    server.on('tail', () => {
-      const [log1, log2] = interceptOut.filter('cid')
+  const options = { correlator: true }
 
-      t.truthy(log1)
-      t.truthy(log2)
-      t.is(log1, log2)
-      t.is(log1, 'cid foobar\n')
-      t.is(log2, 'cid foobar\n')
+  const injection = {
+    method: 'GET',
+    url: '/request/id',
+    headers: {
+      'x-correlation-id': 'foobar'
+    }
+  }
+
+  let log1
+
+  helpers.spawn('inject', options, injection, (log) => {
+    t.truthy(log)
+    t.regex(log, /^cid foobar/)
+
+    if (!log1) {
+      log1 = log
+    } else {
+      t.is(log1, log)
       t.end()
-    })
-
-    server.inject({
-      method: 'GET',
-      url: '/request/id',
-      headers: {
-        'x-correlation-id': 'foobar'
-      }
-    })
-  })
+    }
+  }, undefined, 'on')
 })
 
 test.cb.serial('use a set custom header', (t) => {
-  helpers.getServer({ correlator: { enabled: true, header: 'x-foobar-id' } }, (server) => {
-    server.on('tail', () => {
-      const [log1, log2] = interceptOut.filter('cid')
+  const options = {
+    correlator: {
+      enabled: true,
+      header: 'x-foobar-id'
+    }
+  }
 
-      t.truthy(log1)
-      t.truthy(log2)
-      t.is(log1, log2)
-      t.is(log1, 'cid foobar\n')
-      t.is(log2, 'cid foobar\n')
+  const injection = {
+    method: 'GET',
+    url: '/request/id',
+    headers: {
+      'x-foobar-id': 'foobar'
+    }
+  }
+
+  let log1
+
+  helpers.spawn('inject', options, injection, (log) => {
+    t.truthy(log)
+    t.regex(log, /^cid foobar/)
+
+    if (!log1) {
+      log1 = log
+    } else {
+      t.is(log1, log)
       t.end()
-    })
-
-    server.inject({
-      method: 'GET',
-      url: '/request/id',
-      headers: {
-        'x-foobar-id': 'foobar'
-      }
-    })
-  })
+    }
+  }, undefined, 'on')
 })

--- a/test/fixtures/console.js
+++ b/test/fixtures/console.js
@@ -1,0 +1,5 @@
+const helpers = require('../_helpers')
+
+helpers.getServer(JSON.parse(process.argv[2]), (server) => {
+  console.warn(...JSON.parse(process.argv[3]))
+})

--- a/test/fixtures/inject.js
+++ b/test/fixtures/inject.js
@@ -1,5 +1,5 @@
 const helpers = require('../_helpers')
 
 helpers.getServer(JSON.parse(process.argv[2]), (server) => {
-  throw new Error('foobar')
+  server.inject(JSON.parse(process.argv[3]))
 })

--- a/test/fixtures/log.js
+++ b/test/fixtures/log.js
@@ -1,0 +1,6 @@
+const helpers = require('../_helpers')
+
+helpers.getServer(JSON.parse(process.argv[2]), (server) => {
+  const logs = JSON.parse(process.argv[3])
+  server.log(logs.tags, ...logs.value)
+})

--- a/test/fixtures/postformatter.js
+++ b/test/fixtures/postformatter.js
@@ -1,0 +1,11 @@
+const helpers = require('../_helpers')
+
+const options = Object.assign({
+  preformatter: (data) => ({ foo: 'bar' }),
+  postformatter: (data) => (JSON.stringify({ bar: 'foo' }))
+}, JSON.parse(process.argv[2]))
+
+helpers.getServer(options, (server) => {
+  const logs = JSON.parse(process.argv[3])
+  server.log(logs.tags, ...logs.value)
+})

--- a/test/fixtures/preformatter.js
+++ b/test/fixtures/preformatter.js
@@ -1,0 +1,10 @@
+const helpers = require('../_helpers')
+
+const options = Object.assign({
+  preformatter: (data) => ({ foo: 'bar' })
+}, JSON.parse(process.argv[2]))
+
+helpers.getServer(options, (server) => {
+  const logs = JSON.parse(process.argv[3])
+  server.log(logs.tags, ...logs.value)
+})

--- a/test/fixtures/startStop.js
+++ b/test/fixtures/startStop.js
@@ -1,0 +1,7 @@
+const helpers = require('../_helpers')
+
+helpers.getServer(JSON.parse(process.argv[2]), (server) => {
+  server.start().then(() => {
+    server.stop({ timeout: 100 })
+  })
+})

--- a/test/fixtures/token.js
+++ b/test/fixtures/token.js
@@ -1,8 +1,11 @@
 const helpers = require('../_helpers')
-const laabr = require('../../src')
 
-laabr.token('hello', () => 'HI!')
+const options = Object.assign({
+  tokens: {
+    hello: () => 'HI!'
+  }
+}, JSON.parse(process.argv[2]))
 
-helpers.getServer(JSON.parse(process.argv[2]), (server) => {
+helpers.getServer(options, (server) => {
   server.inject(JSON.parse(process.argv[3]))
 })

--- a/test/fixtures/token.js
+++ b/test/fixtures/token.js
@@ -1,0 +1,8 @@
+const helpers = require('../_helpers')
+const laabr = require('../../src')
+
+laabr.token('hello', () => 'HI!')
+
+helpers.getServer(JSON.parse(process.argv[2]), (server) => {
+  server.inject(JSON.parse(process.argv[3]))
+})

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -188,7 +188,7 @@ test.cb.serial('listen to `response` event – no json token', (t) => {
   })
 })
 
-test.cb.serial.only('listen to `response` event – no format', (t) => {
+test.cb.serial('listen to `response` event – no format', (t) => {
   const options = {
     formats: { response: false }
   }
@@ -206,18 +206,31 @@ test.cb.serial.only('listen to `response` event – no format', (t) => {
   })
 })
 
-test.cb.serial('listen to `onPostStart/onPostStop` events', (t) => {
-  laabr.format('onPostStart', ':time :level :message :host[uri]')
+test.cb.serial('listen to `onPostStart` events', (t) => {
+  const options = {
+    formats: { onPostStart: ':time :level :message :host[uri]' },
+    hapiPino: { logEvents: ['onPostStart'] }
+  }
 
-  helpers.getServer(undefined, (server) => {
-    server.start().then(() => {
-      t.truthy(interceptOut.find('info server started http://127.0.0.1:1337'))
+  const injection = {}
 
-      server.stop({ timeout: 1000 }, () => {
-        t.truthy(interceptOut.find('info server stopped'))
-        t.end()
-      })
-    })
+  helpers.spawn('startStop', options, injection, (log) => {
+    t.regex(log, /info server started http:\/\/127.0.0.1:1337/)
+    t.end()
+  })
+})
+
+test.cb.serial('listen to `onPostStart` events', (t) => {
+  const options = {
+    formats: { onPostStart: ':time :level :message :host[uri]' },
+    hapiPino: { logEvents: ['onPostStop'] }
+  }
+
+  const injection = {}
+
+  helpers.spawn('startStop', options, injection, (log) => {
+    t.regex(log, /info server stopped/)
+    t.end()
   })
 })
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,11 +6,11 @@ const laabr = require('../src')
 
 let consoleClone
 
-test.beforeEach('setup interceptor', (t) => {
+test.beforeEach((t) => {
   consoleClone = Object.assign({}, console)
 })
 
-test.afterEach.always('cleanup interceptor', (t) => {
+test.afterEach.always((t) => {
   Object.assign(console, consoleClone)
 })
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,8 +1,6 @@
 const test = require('ava')
-const spawn = require('child_process').spawn
 const path = require('path')
 const helpers = require('./_helpers')
-const laabr = require('../src')
 
 let consoleClone
 
@@ -16,7 +14,7 @@ test.afterEach.always((t) => {
 
 test.cb.serial('listen to `request` event', (t) => {
   const options = {
-    formats: { request: '{ reqId::requestId }'}
+    formats: { request: '{ reqId::requestId }' }
   }
 
   const injection = {
@@ -125,7 +123,7 @@ test.cb.serial('do not listen to `caught` event', (t) => {
 
 test.cb.serial('listen to `response` event – customized/token', (t) => {
   const options = {
-    formats: { response: ':hello' },
+    formats: { response: ':hello' }
   }
 
   const injection = {
@@ -477,4 +475,3 @@ test.cb.serial('get log message by overriden `console.warn` – multiple', (t) 
     t.end()
   })
 })
-

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -410,56 +410,70 @@ test.cb.serial('listen to `log` event – inline strings – double quotes', (t)
 })
 
 test.cb.serial('preformat the originally logged message', (t) => {
-  const mockData = 'foo'
-  const preformatter = (data) => ({ foo: 'bar' })
+  const options = {
+    indent: 0,
+    formats: { log: false },
+    hapiPino: { logEvents: false }
+  }
 
-  laabr.format('log', false)
+  const logs = {
+    tags: ['info'],
+    value: ['foo']
+  }
 
-  helpers.getServer({ preformatter, indent: 0 }, (server) => {
-    server.log(['info'], mockData)
-    const result = JSON.parse(interceptOut.find('"foo":"bar"').string)
-
-    t.truthy(result)
-    t.truthy(result.foo)
-    t.deepEqual(result.foo, 'bar')
-    t.deepEqual(Object.keys(result).sort(), ['foo'].sort())
+  helpers.spawn('preformatter', options, logs, (log) => {
+    t.truthy(log.foo)
+    t.deepEqual(log.foo, 'bar')
     t.end()
   })
 })
 
 test.cb.serial('postformat the originally logged message', (t) => {
-  const mockData = 'foo'
-  const preformatter = (data) => ({ foo: 'bar' })
-  const postformatter = (data) => (JSON.stringify({ bar: 'foo' }))
+  const options = {
+    indent: 0,
+    formats: { log: false },
+    hapiPino: { logEvents: false }
+  }
 
-  laabr.format('log', false)
+  const logs = {
+    tags: ['info'],
+    value: ['foo']
+  }
 
-  helpers.getServer({ preformatter, postformatter, indent: 0 }, (server) => {
-    server.log(['info'], mockData)
-    const result = JSON.parse(interceptOut.find('"bar":"foo"').string)
-
-    t.truthy(result)
-    t.falsy(result.foo)
-    t.truthy(result.bar)
-    t.deepEqual(result.bar, 'foo')
-    t.deepEqual(Object.keys(result).sort(), ['bar'].sort())
+  helpers.spawn('postformatter', options, logs, (log) => {
+    t.falsy(log.foo)
+    t.truthy(log.bar)
+    t.deepEqual(log.bar, 'foo')
     t.end()
   })
 })
 
 test.cb.serial('get log message by overriden `console.warn` – single', (t) => {
-  helpers.getServer({ indent: 0, override: true }, () => {
-    console.warn('foobar')
-    t.truthy(interceptOut.find('"message":"foobar"'))
+  const options = {
+    indent: 0,
+    override: true,
+    hapiPino: { logEvents: false }
+  }
+
+  const logs = ['foobar']
+
+  helpers.spawn('console', options, logs, (log) => {
+    t.is(log.message, 'foobar')
     t.end()
   })
 })
 
 test.cb.serial('get log message by overriden `console.warn` – multiple', (t) => {
-  helpers.getServer({ indent: 0, override: true }, () => {
-    console.warn('foo', 'bar')
+  const options = {
+    indent: 0,
+    override: true,
+    hapiPino: { logEvents: false }
+  }
 
-    t.truthy(interceptOut.find('"message":["foo","bar"]'))
+  const logs = ['foo', 'bar']
+
+  helpers.spawn('console', options, logs, (log) => {
+    t.deepEqual(log.message, ['foo', 'bar'])
     t.end()
   })
 })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -5,11 +5,11 @@ const validator = require('../src/validator')
 
 let consoleClone
 
-test.beforeEach('setup interceptor', (t) => {
+test.beforeEach((t) => {
   consoleClone = Object.assign({}, console)
 })
 
-test.afterEach('cleanup interceptor', (t) => {
+test.afterEach((t) => {
   Object.assign(console, consoleClone)
 })
 

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,6 +1,7 @@
 const test = require('ava')
 const helpers = require('./_helpers')
 const utils = require('../src/utils')
+const validator = require('../src/validator')
 
 let consoleClone
 
@@ -67,4 +68,8 @@ test('get objectified error', (t) => {
 
 test('get error its source', (t) => {
   t.regex(utils.getErrorSource(new Error('foobar')), new RegExp(`^${__filename}:\\d+:\\d+$`))
+})
+
+test('return value if no validator is defined', (t) => {
+  t.is(validator('foobar', 'foobar'), 'foobar')
 })

--- a/test/validator.spec.js
+++ b/test/validator.spec.js
@@ -1,6 +1,0 @@
-const test = require('ava')
-const validator = require('../src/validator')
-
-test('return value if no validator is defined', (t) => {
-  t.is(validator('foobar', 'foobar'), 'foobar')
-})


### PR DESCRIPTION
Move all tests listening on `stderr/stdout` to `child_process.spawn` for better debugging and as preparation for v17 support