### PR TITLE
fixed registering plugin bug; updated readme and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const server = hapi.server({
 Finally register the plugin and set the correct options:
 ``` js
 await server.register({
-  register: laabr.plugin,
+  plugin: laabr,
   options: {},
 });
 ```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const server = hapi.server({
 Finally register the plugin and set the correct options:
 ``` js
 await server.register({
-  plugin: laabr,
+  plugin: laabr.plugin,
   options: {},
 });
 ```
@@ -117,7 +117,7 @@ server.route([
 (async () => {
   try {
     await server.register({
-      register: laabr.plugin,
+      plugin: laabr.plugin,
       options
     });
     await server.start();

--- a/examples/custom.js
+++ b/examples/custom.js
@@ -33,7 +33,7 @@ server.route([
 (async () => {
   try {
     await server.register({
-      plugin: laabr,
+      plugin: laabr.plugin,
       options
     });
     await server.start();

--- a/examples/custom.js
+++ b/examples/custom.js
@@ -33,7 +33,7 @@ server.route([
 (async () => {
   try {
     await server.register({
-      register: laabr.plugin,
+      plugin: laabr,
       options
     });
     await server.start();

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -23,7 +23,7 @@ server.route([
 (async () => {
   try {
     await server.register({
-      plugin: laabr,
+      plugin: laabr.plugin,
       options: {}
     });
     await server.start();

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -23,7 +23,7 @@ server.route([
 (async () => {
   try {
     await server.register({
-      register: laabr.plugin,
+      plugin: laabr,
       options: {}
     });
     await server.start();


### PR DESCRIPTION
Tried to install the plugin and got the following exception: 

[1] "register" must be a Function
    at Object.exports.apply (/home/torstein/tmp/laabr/node_modules/hapi/lib/config.js:22:10)
    at internals.Server.register (/home/torstein/tmp/laabr/node_modules/hapi/lib/server.js:364:31)
    at __dirname (/home/torstein/tmp/laabr/examples/simple.js:25:18)
    at Object.<anonymous> (/home/torstein/tmp/laabr/examples/simple.js:34:3)
    at Module._compile (module.js:641:30)
    at Object.Module._extensions..js (module.js:652:10)
    at Module.load (module.js:560:32)
    at tryModuleLoad (module.js:503:12)
    at Function.Module._load (module.js:495:3)
    at Function.Module.runMain (module.js:682:10)
  generatedMessage: false,
  name: 'AssertionError [ERR_ASSERTION]',
  code: 'ERR_ASSERTION',
  actual: false,
  expected: true,
  operator: '==' }

Updated the plugin registering to match the v.17 API, as well as updated the README.md