### PR TITLE
Fix URL not appearing in log issue

### DIFF
--- a/src/tokens.js
+++ b/src/tokens.js
@@ -151,7 +151,7 @@ assign('remotePort', data => (
 ))
 
 assign('url', data => (
-  data.req && data.req.url
+  data.req && data.req.url.href || data.req.url 
 ))
 
 assign('host', (data, colors, field = 'host') => {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -151,7 +151,7 @@ assign('remotePort', data => (
 ))
 
 assign('url', data => (
-  data.req && data.req.url && data.req.url.href
+  data.req && data.req.url
 ))
 
 assign('host', (data, colors, field = 'host') => {

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -151,7 +151,7 @@ assign('remotePort', data => (
 ))
 
 assign('url', data => (
-  data.req && data.req.url.href || data.req.url 
+  data.req && data.req.url && data.req.url.href || data.req.url 
 ))
 
 assign('host', (data, colors, field = 'host') => {


### PR DESCRIPTION
Related to #67 

After some digging I found that this issue was not happening on version 5 of laadr. 
After comparing the two: https://github.com/felixheck/laabr/compare/v5.1.6...v6.1.1
I found that this line:
```
assign('url', data => (	
  data.req && data.req.url
))
```
was changed to this:
```
assign('url', data => (
  data.req && data.req.url && data.req.url.href
))
```

When I change it back i get the desired output
<img width="453" alt="Screen Shot 2020-10-22 at 10 48 11 AM" src="https://user-images.githubusercontent.com/42663507/96888901-16f69800-1454-11eb-8881-c1ea6f508316.png">
